### PR TITLE
Allow Green/Red to show properly in console Vim

### DIFF
--- a/lib/simplecov-vim/coverage.vim.erb
+++ b/lib/simplecov-vim/coverage.vim.erb
@@ -1,7 +1,7 @@
 "hi HitLine ctermbg=Cyan guibg=Cyan
 "hi MissLine ctermbg=Magenta guibg=Magenta
-hi HitSign ctermfg=Green cterm=bold gui=bold guifg=Green
-hi MissSign ctermfg=Red cterm=bold gui=bold guifg=Red
+hi HitSign ctermfg=034 cterm=bold gui=bold guifg=Green
+hi MissSign ctermfg=009 cterm=bold gui=bold guifg=Red
 
 sign define hit  linehl=HitLine  texthl=HitSign  text=>>
 sign define miss linehl=MissLine texthl=MissSign text=:(


### PR DESCRIPTION
In console vim prior to this mod, red worked, but green showed up Gray. I pulled the values from here:

[http://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg](http://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg)

...and they seem to work well.
